### PR TITLE
Fix "euler" distance in sampen

### DIFF
--- a/nolds/measures.py
+++ b/nolds/measures.py
@@ -650,7 +650,7 @@ def sampen(data, emb_dim=2, tolerance=None, dist="chebychev",
       if dist == "chebychev":
         dsts = np.max(np.abs(diff), axis=1)
       elif dist == "euler":
-        dsts = np.norm(diff, axis=1)
+        dsts = np.linalg.norm(diff, axis=1)
       else:
         raise "unknown distance function: %s" % dist
       if debug_plot:


### PR DESCRIPTION
Since np.norm doesn't exist (and returns an error), I though you meant [np.linalg.norm](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.norm.html).