### PR TITLE
Changed behavior of lstsq to keep consistent between numpy versions

### DIFF
--- a/nolds/measures.py
+++ b/nolds/measures.py
@@ -509,7 +509,7 @@ def lyap_e(data, emb_dim=10, matrix_dim=4, min_nb=None, min_tsep=0, tau=1,
     vec_beta = data[indices + matrix_dim * m] - data[i + matrix_dim * m]
 
     # perform linear least squares
-    a, _, _, _ = np.linalg.lstsq(mat_X, vec_beta)
+    a, _, _, _ = np.linalg.lstsq(mat_X, vec_beta, rcond=-1)
     # build matrix T
     # 0  1  0  ... 0
     # 0  0  1  ... 0


### PR DESCRIPTION
This makes a small change to avoid a Future Warning as well as avoid a behavior change in the code. 

NumPy's Linsq function (numpy.linalg.lsqsq) has a future warning due to the rcond parameter not being set in the nolds library. I'm guessing, based on the timing of this project, that the appropriate choice is rcond = -1, which is the behavior from numpy previous to 1.14. 

The new default behavior in numpy > 1.14 is "rcond = None" which means that if a user updates numpy from < 1.14 to > 1.14 they could, conceivably, get slightly different results when running code without this change. 

Also, this removes a Future Warning.