### PR TITLE
Switch from pkg_resources to importlib for future deprecation

### DIFF
--- a/nolds/datasets.py
+++ b/nolds/datasets.py
@@ -6,7 +6,7 @@ from builtins import (
   oct, open, pow, round, super, filter, map, zip
 )
 import numpy as np
-import pkg_resources
+from importlib import resources
 import datetime
 
 
@@ -144,7 +144,7 @@ def load_qrandom():
       the dataset
   """
   fname = "datasets/qrandom.npy"
-  with pkg_resources.resource_stream(__name__, fname) as f:
+  with resources.files(__name__).joinpath(fname).open('rb') as f:
     return np.load(f)
 
 
@@ -159,7 +159,7 @@ def load_brown72():
       the dataset
   """
   fname = "datasets/brown72.npy"
-  with pkg_resources.resource_stream(__name__, fname) as f:
+  with resources.files(__name__).joinpath(fname).open('rb') as f:
     return np.load(f)
 
 
@@ -185,10 +185,10 @@ def load_lorenz_physionet():
       x- and y-coordinates of the line fitting step in the PhysioNet output
   """
   fname = "datasets/lorenz.txt"
-  with pkg_resources.resource_stream(__name__, fname) as f:
+  with resources.files(__name__).joinpath(fname).open('rb') as f:
     data_in = np.loadtxt(f)
   fname = "datasets/lorenz_physionet.txt"
-  with pkg_resources.resource_stream(__name__, fname) as f:
+  with resources.files(__name__).joinpath(fname).open('rb') as f:
     data_out = np.loadtxt(f)
   return data_in, data_out
 
@@ -393,7 +393,7 @@ def load_financial():
   data = []
   for index in ["^JKSE", "^N225", "^NDX"]:
     fname = "datasets/{}.csv".format(index)
-    with pkg_resources.resource_stream(__name__, fname) as f:
+    with resources.files(__name__).joinpath(fname).open('rb') as f:
       days, values = load_finance_yahoo_data(f)
       pad_opening_values(values)
       data.append((days, values))


### PR DESCRIPTION
Hi,
the pkg_resources package is going to be deprecated. I changed the code to reflect the future API that uses importlib instead. This prevents warnings like `The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.`

importlib.resources is present since Python 3.7, so it should be working fine also with previous Python versions (tests passed on v3.12.11)